### PR TITLE
class="MathMLNoDisplay" was missing from the MathML therefor was rendered onscreen instead of off-screen.

### DIFF
--- a/content/epub30-test-0330/OEBPS/Text/epub-image-math-examples.xhtml
+++ b/content/epub30-test-0330/OEBPS/Text/epub-image-math-examples.xhtml
@@ -33,7 +33,7 @@
       <span class="note">(first expression)</span>
 
         <span id="exp1" class="MathMLNoJavaHidden" aria-hidden="true">
-          <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline" alttext="(mathml alt-text): x sub 1, y sub 1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML" class="MathMLNoDisplay" display="inline" alttext="(mathml alt-text): x sub 1, y sub 1">
             <mo>(</mo>
             <msub> <mi>x</mi><mn>1</mn></msub>
             <mo>,</mo>
@@ -48,7 +48,7 @@
         <span class="note">(second expression)</span>
 
         <span id="exp2" class="MathMLNoJavaHidden" aria-hidden="true">
-          <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline" alttext="(mathml alt-text): x sub 2 y sub 2">
+          <math xmlns="http://www.w3.org/1998/Math/MathML" class="MathMLNoDisplay" display="inline" alttext="(mathml alt-text): x sub 2 y sub 2">
             <mo>(</mo>
             <msub> <mi>x</mi><mn>2</mn> </msub>
             <mo>,</mo>
@@ -64,7 +64,7 @@
     <p>
         <span class="note">(third expression)</span>
         <span id="exp3" class="MathMLNoJavaHidden" aria-hidden="true">
-            <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="(mathml alt-text): y minus y 1 equals StartFraction y 2 minus y 1 Over x 2 minus x 1 EndFraction left-parenthesis x minus x 1 right-parenthesis">
+            <math xmlns="http://www.w3.org/1998/Math/MathML" class="MathMLNoDisplay" display="block" alttext="(mathml alt-text): y minus y 1 equals StartFraction y 2 minus y 1 Over x 2 minus x 1 EndFraction left-parenthesis x minus x 1 right-parenthesis">
               <mrow>
                 <mstyle displaystyle="true">
                   <mi>y</mi>
@@ -130,7 +130,7 @@
         <span>where</span>
         <span class="note">(fourth expression)</span>
         <span id="exp4" class="MathMLNoJavaHidden" aria-hidden="true">
-          <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline" alttext="(mathml alt-text): x sub 2 not-equals x sub 1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML" class="MathMLNoDisplay" display="inline" alttext="(mathml alt-text): x sub 2 not-equals x sub 1">
             <msub> <mi>x</mi><mn>2</mn> </msub>
             <mo>≠<!-- not equals --></mo>
             <msub> <mi>x</mi><mn>1</mn> </msub>


### PR DESCRIPTION
This may have been something I did on accident when I was adding the last MathML only test.  Fixed the problem of the mathML rendered in test 010 along side the image.