### PR TITLE
Fix sample text in nav-005

### DIFF
--- a/content/epub30-test-0300/EPUB/xhtml/Basic-functionality-tests.xhtml
+++ b/content/epub30-test-0300/EPUB/xhtml/Basic-functionality-tests.xhtml
@@ -55,16 +55,15 @@
     <ul>
         <li>Cover page - First entry in the TOC, this is at level 1</li>
         <li>Front page - Second entry in the TOC, this is at level 1</li>
-        <li>Table of Contents - Third entry in the TOC, this is at level 1</li>
-        <li>Introduction - Fourth entry in the TOC, this is at level 1</li>
-        <li>Basic Functionality Tests - Fifth entry in the TOC, this is also at level 1
+        <li>Introduction - Third entry in the TOC, this is at level 1</li>
+        <li>Basic Functionality Tests - Fourth entry in the TOC, this is also at level 1
         <ul>
-			<li>Operating system accessibility - Sixth entry in the TOC, this is at level 2</li>
-			<li>Reading system activation - Seventh entry in the TOC, this is at level 2</li>
-			<li>Open content - Eighth entry in the TOC, this is at level 2</li>
-			<li>Listing documents - Ninth entry in the TOC, this is also at level 2</li>
+			<li>Operating system accessibility - Fifth entry in the TOC, this is at level 2</li>
+			<li>Reading system activation - Sixth entry in the TOC, this is at level 2</li>
+			<li>Open content - Seventh entry in the TOC, this is at level 2</li>
+			<li>Listing documents - Eighth entry in the TOC, this is also at level 2</li>
 		</ul></li>
-        <li>Navigation Tests - Tenth entry in the TOC, this is at level 1</li>
+        <li>Navigation Tests - Ninth entry in the TOC, this is at level 1</li>
     </ul>
     <p class="eval">Indicate Pass or Fail.</p>
     </section>


### PR DESCRIPTION
TOC isn't listed in TOC now, so this item has been removed from sample text, and fixed ordinal numbers for corresponding list items.