### PR TITLE
Moved the back link to be first, and fixed first alttext in MathML

### DIFF
--- a/content/epub30-test-0302/EPUB/xhtml/Non_Visual_Reading_Tests.xhtml
+++ b/content/epub30-test-0302/EPUB/xhtml/Non_Visual_Reading_Tests.xhtml
@@ -75,9 +75,10 @@
    </p>
 <p>This is a filler paragraph to show there would be text between the note reference and the footnote.</p>
 <aside id="ft2f" role="doc-footnote" epub:type="footnote">
+<p><a href="#backlink-target" role="doc-backlink">[return to note reference 1 about Chief Joseph]</a></p>
    <p>
      1 The Appaloosa is a spotted horse breed that originated from the selective breeding practices of the Nez Perce tribe in the northwestern U.S. The Nez Perce valued the Appaloosa for its speed, endurance, intelligence, and spiritual power. The name Appaloosa may have derived from the Palouse River or the Palouse tribe, which were associated with the Nez Perce. The Appaloosa is the official state horse of Idaho and a symbol of the region </p>
-   <p><a href="#backlink-target" role="doc-backlink">[return to note reference 1 about Chief Joseph]</a></p>
+   
 </aside>
 
 <p>End of the footnote testing item.</p>
@@ -255,7 +256,7 @@ Indicate Pass or Fail.</p>
     <hr/>
         Text before block math.
         <span id="exp4">
-            <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="(MathML alttext): y minus y 1 equals StartFraction y 2 minus y 1 Over x 2 minus x 1 EndFraction left-parenthesis x minus x 1 right-parenthesis">
+            <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="(MathML alttext): y minus y sub 1 equals StartFraction y sub 2 minus y sub 1 Over x sub 2 minus x sub 1 EndFraction left-parenthesis x minus x sub 1 right-parenthesis">
               <mrow>
                 <mstyle displaystyle="true">
                   <mi>y</mi>


### PR DESCRIPTION
I moved the backlink to before the footnote text. I also modified the first MathML alttext to be the same as the second, because the MathML is the same, the alttext should also be the same.