### PR TITLE
 Non visual updates

### DIFF
--- a/content/epub30-test-0302/EPUB/package.opf
+++ b/content/epub30-test-0302/EPUB/package.opf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid" xml:lang="en">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    <dc:identifier id="uid">com.github.epub-testsuite.epub30-test-0302-2.0.0</dc:identifier>
+    <dc:identifier id="uid">com.github.epub-testsuite.epub30-test-0302-2.0.1</dc:identifier>
     <dc:identifier id="isbn-id">9781000850512</dc:identifier>
     <meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15</meta>
     <dc:title>Fundamental Accessibility Tests: Non-Visual Reading</dc:title>
@@ -30,7 +30,7 @@
 	  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
 	  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
 	  <meta property="schema:accessibilitySummary">This publication strives to conform to WCAG 2.0 Level AA.</meta>
-    <meta property="schema:version">2.0.0</meta>	
+    <meta property="schema:version">2.0.1</meta>
   </metadata>
   <manifest>
     <!-- css -->
@@ -52,8 +52,8 @@
     <item href="xhtml/Non_Visual_Reading_Tests.xhtml" id="xhtml-001" properties="mathml" media-type="application/xhtml+xml"/>
     <item href="xhtml/supplement.xhtml" id="xhtml-002" media-type="application/xhtml+xml"/>
 
- 
-    
+
+
   </manifest>
   <spine>
     <itemref idref="cover"/>

--- a/content/epub30-test-0302/EPUB/xhtml/Non_Visual_Reading_Tests.xhtml
+++ b/content/epub30-test-0302/EPUB/xhtml/Non_Visual_Reading_Tests.xhtml
@@ -65,7 +65,7 @@
 <li>Assistive technology is able to read the content of the footnote.</li>
 <li>The Reading System  provides a mechanism to move back to the original reading position from the footnote, or the backlink is used to return to the original position.</li>
 </ul>
-   
+
     <p class="eval">Indicate Pass or Fail.</p>
 
 <p>Please put into the notes if the link to the note was announced, and upon reaching the destination  that it was a footnote. Include if the Reading System included its own mechanism to return to the original location or if the backlink was announced and used to return to the exact location.</p>
@@ -78,7 +78,7 @@
 <p><a href="#backlink-target" role="doc-backlink">[return to note reference 1 about Chief Joseph]</a></p>
    <p>
      1 The Appaloosa is a spotted horse breed that originated from the selective breeding practices of the Nez Perce tribe in the northwestern U.S. The Nez Perce valued the Appaloosa for its speed, endurance, intelligence, and spiritual power. The name Appaloosa may have derived from the Palouse River or the Palouse tribe, which were associated with the Nez Perce. The Appaloosa is the official state horse of Idaho and a symbol of the region </p>
-   
+
 </aside>
 
 <p>End of the footnote testing item.</p>
@@ -86,7 +86,7 @@
 
 
   <section id="reading-510" class="test">
-    <h2><span class="test-id">reading-510</span> <span class="test-title">TTS allows pause for indicating headings, paragraphs, list items, etc</span></h2> 
+    <h2><span class="test-id">reading-510</span> <span class="test-title">TTS allows pause for indicating headings, paragraphs, list items, etc</span></h2>
     <p class="desc">The user should be able to identify the difference between content items such as headings, paragraphs or list items by sufficient pauses in the TTS reading or appropriate formatting in the Braille device.</p>
     <p>Read the text below using TTS and listen for the pauses.</p>
     <h3>Text for testing TTS</h3>
@@ -250,13 +250,13 @@
 <p class="eval">Check if the assistive technology reports the presence of the MathML expressions in both     samples. Check that both of  the MathML expressions are read correctly, and the elements of the math expressions can be explored at different levels using the features of the assistive technology.
 The test fails if you  cannot read/hear the equation containing an equals sign and the presence of a fraction contained within.
 Indicate Pass or Fail.</p>
- 
+
 <h3>MathML Block Test</h3>
     <p>Block Math Equation will appear between the following two lines.</p>
     <hr/>
         Text before block math.
         <span id="exp4">
-            <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="(MathML alttext): y minus y sub 1 equals StartFraction y sub 2 minus y sub 1 Over x sub 2 minus x sub 1 EndFraction left-parenthesis x minus x sub 1 right-parenthesis">
+            <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" >
               <mrow>
                 <mstyle displaystyle="true">
                   <mi>y</mi>
@@ -325,7 +325,7 @@ Indicate Pass or Fail.</p>
     <hr/>
         Text before inline math.
         <span id="exp3">
-            <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline" alttext="(MathML alttext): y minus y sub 1 equals StartFraction y sub 2 minus y sub 1 Over x sub 2 minus x sub 1 EndFraction left-parenthesis x minus x sub 1 right-parenthesis">
+            <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline" >
               <mrow>
                 <mstyle displaystyle="true">
                   <mi>y</mi>

--- a/content/epub30-test-0302/EPUB/xhtml/Non_Visual_Reading_Tests.xhtml
+++ b/content/epub30-test-0302/EPUB/xhtml/Non_Visual_Reading_Tests.xhtml
@@ -157,12 +157,12 @@
     <p class="desc">Check if you can navigate between internal hyperlinks.</p>
     <ol>
       <li>Navigate to and select the internal hyperlink.</li>
-      <li>Verify that focus has moved to new location.</li>
-      <li>Navigate to and select the Back hyperlink.</li>
-      <li>Verify that focus is returned to original location. </li>
+      <li>Verify that focus has moved to the new location.</li>
+
     </ol>
-    <p class="eval">If you can navigate from this paragraph to the link target by selecting <a href="supplement.xhtml#link-target-1">this link</a>, and if the link on the destination page returns you to the paragraph below, then the test passes.</p>
-    <p id="link-target-1a">You will be returned to this location by following the link back.</p>
+    <p class="eval">If you can navigate from this paragraph to the link target by selecting <a href="supplement.xhtml#link-target-1">this link</a></p>
+    <p id="link-target-1a">, then this test passes.</p>
+    <p>Please check if the reading system has a go-back feature that allows you to return to this location. Place information about this functionality in the notes.</p>
   </section>
   <section id="reading-810" class="test">
     <h2><span class="test-id">reading-810</span> <span class="test-title">Move to the next block item</span></h2>

--- a/content/epub30-test-0302/EPUB/xhtml/supplement.xhtml
+++ b/content/epub30-test-0302/EPUB/xhtml/supplement.xhtml
@@ -12,7 +12,7 @@
 	<h1>Supplemental content</h1>
 	<p>There are no tests on this page; rather, it functions as a helper page for existing tests.</p>
 	<section id="link-target">
-		<p id="link-target-1">This is a sample link target for the first hyperlink navigation test. <a href="Non_Visual_Reading_Tests.xhtml#link-target-1a">Follow this link to go back.</a></p>
+		<p id="link-target-1">This is a sample link target for the first hyperlink navigation test. Check if the reading system has a mechanism to go back. If the reading system takes you back, please report this in the notes.</p>
 	</section>
 </body>
 


### PR DESCRIPTION
There are four changes to the non-visual fundamental test book.

1. I updated the version to 2.0.1
2. I removed the alttext in the two mathML entries.
3. I updated test 710 to not follow the backlink. I put in a note to test if the reading system has a go back function.
4. I removed the backlink in the supplemental.
I did run it through EPUBcheck and built the book. I tested it in Thorium.